### PR TITLE
Removing leading 'v' from META6.json

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -1,7 +1,7 @@
 {
   "name" : "Getopt::Tiny",
   "source-url" : "git://github.com/tokuhirom/p6-Getopt-Tiny.git",
-  "perl" : "v6",
+  "perl" : "6",
   "build-depends" : [ ],
   "provides" : {
     "Getopt::Tiny" : "lib/Getopt/Tiny.pm6"


### PR DESCRIPTION
It's a trivial change, but I get this message when installing via Panda:

==> Fetching Getopt::Tiny
Please remove leading 'v' from perl version in Getopt::Tiny's meta info.

Trivial, I thought I'd send a quick PR to solve this problem.